### PR TITLE
feat: add self-marketplace.json for single-repo install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,31 @@
+{
+  "name": "mac-doctor",
+  "owner": {
+    "name": "pierrelzw"
+  },
+  "metadata": {
+    "description": "Single-plugin marketplace for mac-doctor"
+  },
+  "plugins": [
+    {
+      "name": "mac-doctor",
+      "source": "./.",
+      "description": "macOS system doctor — system info, disk cleanup, and maintenance",
+      "version": "0.1.0",
+      "author": {
+        "name": "pierrelzw"
+      },
+      "repository": "https://github.com/pierrelzw/mac-doctor",
+      "license": "MIT",
+      "keywords": [
+        "macos",
+        "system",
+        "cleanup",
+        "disk",
+        "maintenance",
+        "diagnostics"
+      ],
+      "category": "system"
+    }
+  ]
+}


### PR DESCRIPTION
Allows installing this plugin directly via `/plugin marketplace add pierrelzw/mac-doctor` in addition to the zhiwei_skills hub. `source: "./."` works for both local-path (dev testing) and GitHub install. Pilot verified on xiaoyuzhou-to-audio.